### PR TITLE
Smart constructor for params

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,10 +41,10 @@ getHomeR = defaultLayout $ do
       key = Key "my_key"
       template = Template "my_template"
       secret = Secret "my_secret"
-      params = TransloaditParams expiry key template ident secret
+      params = mkParams expiry key template ident secret
 
   -- Load the widget, and retrieve the given signature
-  sig <- transloadIt params
+  sig <- either (const $ error "nooo") transloadIt params
 
   -- CSRF considerations, tokenText is a helper that tries to extract the current CSRF token
   t <- tokenText

--- a/src/Web/Transloadit.hs
+++ b/src/Web/Transloadit.hs
@@ -7,7 +7,18 @@
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE ViewPatterns          #-}
 
-module Web.Transloadit where
+module Web.Transloadit (
+    Key(..),
+    Template(..),
+    Secret(..),
+    TransloaditParams,
+    mkParams,
+    tokenText,
+    handleTransloadit,
+    YesodTransloadit,
+    transloadIt,
+    extractFirstResult
+  ) where
 
 import           Control.Applicative
 import           Control.Monad
@@ -51,6 +62,13 @@ data TransloaditParams = TransloaditParams {
   formIdent           :: Text,
   transloaditSecret   :: Secret
 } deriving (Show)
+
+data ParamsError = UnknownError
+type ParamsResult = Either ParamsError TransloaditParams
+
+-- Give us the ability for greater validation rules in future
+mkParams :: UTCTime -> Key -> Template -> Text -> Secret -> ParamsResult
+mkParams u k t f s = return (TransloaditParams u k t f s)
 
 data TransloaditResponse = TransloaditResponse { raw :: Text, token :: Text } deriving (Show)
 

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -37,10 +37,10 @@ getHomeR = defaultLayout $ do
       key = Key "my_key"
       template = Template "my_template"
       secret = Secret "my_secret"
-      params = TransloaditParams expiry key template ident secret
+      params = mkParams expiry key template ident secret
 
   -- Load the widget, and retrieve the given signature
-  sig <- transloadIt params
+  sig <- either (const $ error "nooo") transloadIt params
 
   -- CSRF considerations
   t <- tokenText


### PR DESCRIPTION
Instead of using the `TransloaditParams` record constructor, this change adds `mkParams`. This will give us the ability to add validation to params cleanly if we need to. The initial error data `UnknownError` has been added. To enforce the static validation of the smart constructor, we hide the record constructor (so there is no backdoor into invalid params). The readme and the tests have to be updated as now `mkParams` is the only way to create params.
