### PR TITLE
OrderedJSON DSL

### DIFF
--- a/src/Yesod/Transloadit/OrderedJSON.hs
+++ b/src/Yesod/Transloadit/OrderedJSON.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Yesod.Transloadit.OrderedJSON (
+    encode,
+    is,
+    obj,
+    str
+  ) where
+
+import           Data.Text
+
+type KeyValue = (Text, OrderedValue)
+
+data OrderedValue = Object [KeyValue] | String Text deriving (Eq, Show)
+
+quote :: Text
+quote = "\""
+
+lbrace :: Text
+lbrace = "{"
+
+rbrace :: Text
+rbrace = "}"
+
+colon :: Text
+colon = ":"
+
+comma :: Text
+comma = ","
+
+encodeKV :: KeyValue -> Text
+encodeKV (t, v) = mconcat [quote, t, quote, colon, encode v]
+
+encode :: OrderedValue -> Text
+encode (String t) = mconcat [quote, t, quote]
+encode (Object kvs) = mconcat [lbrace, intercalate comma $ fmap encodeKV kvs, rbrace]
+
+is :: Text -> OrderedValue -> KeyValue
+is = (,)
+
+obj :: [KeyValue] -> OrderedValue
+obj = Object
+
+str :: Text -> OrderedValue
+str = String

--- a/yesod-transloadit.cabal
+++ b/yesod-transloadit.cabal
@@ -18,6 +18,7 @@ source-repository head
 library
   exposed-modules:     Yesod.Transloadit
   ghc-options:         -Wall
+  other-modules:       Yesod.Transloadit.OrderedJSON
   build-depends:       base < 5
                        , aeson
                        , text


### PR DESCRIPTION
Part of this library is computing the JS frontend snippet for Transloadit. This snippet is signed for "Signature Authentication". Normally we'd use Aeson to produce the JSON, but because it uses a HashMap internally we can't guarantee the key order on output. This makes the output more unpredictable and hard to test between versions -- especially since we test the signature of the output: https://github.com/bobjflong/yesod-transloadit/blob/master/test/Tests.hs#L66

This new module allows a subject of JSON to be represented and encoded, using Aeson-like syntax. But it uses a list to maintain order.

This replaces a bunch of Text contactentation
