### PR TITLE
Refactor to nthStepResult and include more data from Transloadit

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,16 +62,16 @@ getHomeR = defaultLayout $ do
   return ()
 ```
 
-The handler for our form is quite simple, we try to parse the results (using the `extractFirstResult` helper) and present an image:
+The handler for our form is quite simple, we try to parse the results (using the `nthStepResult` helper) and present an image:
 
 ```haskell
 postHomeR :: Handler Html
 postHomeR = defaultLayout $ do
-  results <- handleTransloadit -- "results" is just JSON, we can use extractFirstResult to optionally parse it
+  results <- handleTransloadit -- "results" is just JSON, we can use nthStepResult to optionally parse it
 
   -- my_template contains a step called "cropped_thumb"
-  case extractFirstResult "cropped_thumb" results of
-    Just (String url) -> [whamlet| <img src="#{url}"/> |]
+  case nthStepResult 0 "cropped_thumb" results of
+    Just s -> [whamlet| <img src="#{s ^. sslUrl}"/> |]
     _ -> [whamlet| No results :( |]
 
   return ()

--- a/shell.nix
+++ b/shell.nix
@@ -4,9 +4,10 @@ let
 
   inherit (nixpkgs) pkgs;
 
-  f = { mkDerivation, aeson, base, byteable, bytestring, cryptohash
-      , hspec, lens, lens-aeson, old-locale, shakespeare, stdenv, text
-      , time, transformers, yesod, yesod-core, yesod-form, yesod-test
+  f = { mkDerivation, aeson, base, byteable, bytestring, containers
+      , cryptohash, hspec, lens, lens-aeson, old-locale, shakespeare
+      , stdenv, text, time, transformers, unordered-containers, yesod
+      , yesod-core, yesod-form, yesod-test
       }:
       mkDerivation {
         pname = "yesod-transloadit";
@@ -14,11 +15,12 @@ let
         src = ./.;
         buildDepends = [
           aeson base byteable bytestring cryptohash lens lens-aeson
-          old-locale shakespeare text time transformers yesod yesod-core
-          yesod-form
+          old-locale shakespeare text time transformers unordered-containers
+          yesod yesod-core yesod-form
         ];
         testDepends = [
-          base hspec old-locale text time yesod yesod-form yesod-test
+          aeson base containers hspec lens old-locale text time yesod
+          yesod-form yesod-test
         ];
         description = "Transloadit support for Yesod";
         license = stdenv.lib.licenses.mit;

--- a/yesod-transloadit.cabal
+++ b/yesod-transloadit.cabal
@@ -34,6 +34,7 @@ library
                        , lens
                        , shakespeare
                        , lens-aeson
+                       , unordered-containers
 
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -52,6 +53,9 @@ test-suite tests
                        yesod-form,
                        time,
                        old-locale,
-                       text
+                       text,
+                       lens,
+                       aeson,
+                       containers
 
   default-language:    Haskell2010


### PR DESCRIPTION
This PR adds the `StepResult` product type, which will provide more data from Transloadit, such as the file extension and mime type.

The `extractFirstResult` function (which only returned the `ssl_url`) has been removed.

`nthStepResult` has been added, which returns the nth `StepResult` for a given step key.
